### PR TITLE
Fixed the PredefinedReasons list not being cleared on reload

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>teik.ers</groupId>
     <artifactId>EpicReport</artifactId>
-    <version>4.0.0</version>
+    <version>4.0.1</version>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>

--- a/src/main/java/teik/ers/bukkit/configs/inventories/commandsmenus/PredefinedReportsMenu.java
+++ b/src/main/java/teik/ers/bukkit/configs/inventories/commandsmenus/PredefinedReportsMenu.java
@@ -83,6 +83,10 @@ public class PredefinedReportsMenu {
 
     public void reloadConfig(){
         inventoryFile.reloadConfig();
+
+        predefinedReportList.clear();
+        predefinedListSize = 0;
+
         LoadInventory();
     }
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 main: teik.ers.bukkit.EpicReports
 name: EpicReports
-version: 4.0.0
+version: 4.0.1
 author: teik
 
 commands:


### PR DESCRIPTION
This commit fixes the command '/epicreports reload' not clearing the predefined reports list leading to possible duplicates.